### PR TITLE
Add skills pattern support for syncing entire skill directories

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & run
+
+- `make build` — `go mod tidy` then build to `bin/syncai`.
+- `make run` — builds and then runs `go run ./cmd -config syncai.json`.
+- `make clean` — removes `bin/`.
+
+There is no test suite in this repo (no `*_test.go` files). Verify changes with `make build` plus a manual smoke test against a temp working directory:
+
+```bash
+./bin/syncai -workdir /tmp/syncai-smoke -config /tmp/syncai-smoke/syncai.json -no-watch
+```
+
+CLI flags: `-config`, `-workdir`, `-no-watch` (one-shot for CI), `-self-update`, `-version`, `-help`.
+
+## Architecture
+
+SyncAI is a polling watcher that propagates AI-assistant config files between agents (Cursor, Copilot, Claude Code, Codex). The whole program is a single Go binary; the moving parts split cleanly along four "sync kinds" defined in `internal/model/model.go`:
+
+| Kind     | Source config field      | Source unit            | Destination logic |
+|----------|--------------------------|------------------------|-------------------|
+| context  | `Agent.Context.Path`     | single file            | verbatim copy |
+| ignore   | `Agent.Ignore.Path`      | single file            | verbatim copy |
+| rules    | `Agent.Rules.Pattern`    | files matched by glob  | content rewritten by per-agent rules generator (frontmatter shape differs between cursor's `globs/alwaysApply` and copilot's `applyTo`) |
+| skills   | `Agent.Skills.Pattern`   | **whole directory** matched by glob | every file inside the matched dir copied verbatim, preserving the in-skill relative path |
+
+### Lifecycle
+
+1. `cmd/main.go` loads config, runs `initialSync` (dedup key `kind|stem|rel`, picks the newest mtime per logical file across agents), then enters a ticker loop at `cfg.Interval()` (default 5s).
+2. Each tick rebuilds the watched-file list via `(config.Agent).Files()` and diffs sha256 hashes against the in-memory `filesState`. Changes → `(*SyncAI).Sync`. Missing entries → `(*SyncAI).Delete`.
+3. `Files()` uses two distinct collectors: `globPattern` (file glob, used for rules) and `walkSkillDirs` (recursive walk of every matched directory, used for skills). Don't conflate them.
+
+### `Identify` is the routing decision
+
+`(*SyncAI).Identify(path)` returns `(*config.Agent, model.Kind, stem, rel)`:
+- `stem` is the wildcard capture (skill folder name, or rule file's wildcard portion).
+- `rel` is non-empty only for skills — it's the file's path relative to its skill folder.
+- `Identify` walks the agents in config order; the first match wins. Rules are checked before skills, so don't configure overlapping patterns.
+
+### Pattern matching helpers in `internal/syncai/util.go`
+
+- `matchPattern(pattern, path)` — for file patterns (rules). `*` may appear in any path component. Falls back to basename-without-extension as stem when the pattern has no `*`.
+- `matchSkillsPattern(pattern, path)` — for directory patterns (skills). The pattern is a prefix of the path; the remainder is the rel.
+- `generatePatternPath(pattern, stem)` — substitutes `stem` into every `*` component. For skills, callers join `rel` afterwards in `generatePath`.
+- `skillsBaseDir(pattern)` — the literal prefix of the pattern before its first wildcard component. Used to bound the empty-dir cleanup walk.
+
+### Two sync paths in `(*SyncAI).Sync`
+
+- **Skills** → `syncSkill`: read source bytes once, `util.WriteFile` them to every peer's substituted destination. No frontmatter parsing — skill folders may contain scripts/data that aren't markdown.
+- **Everything else** → document-stack path: parse all peers' versions of the logical file, sort with the changed path forced last (so it wins regardless of mtime), pass through `generate()` which dispatches to a per-agent `RulesGenerator` only when `kind == KindRules`. Context/ignore fall through verbatim.
+
+### Deletes and empty-dir pruning
+
+`(*SyncAI).Delete` only propagates deletions for `KindRules` and `KindSkills` (context/ignore deletions are intentionally non-propagating to avoid accidents). After each successful peer-side skill file removal, `util.PruneEmptyDirs(dirOf(dst), skillsBaseDir(dstAgent.Skills.Pattern))` walks upward removing empty dirs, stopping at the configured base — so `.codex/skills/` survives even when its last skill is deleted.
+
+### Atomic file writes
+
+`util.WriteFile` is the sole writer: temp file in the same dir → fsync → rename → fsync the dir. It returns early if destination bytes already match, which is what prevents ping-pong syncs.
+
+## Frontmatter parsing
+
+`util.ParseFile` extracts YAML frontmatter from markdown. Used by the document-stack path to merge metadata across agents in `generator.ExtractRulesMetadata`. Non-string YAML values are coerced via `cleanYAMLValue`; sequences are joined with commas. Skills bypass this entirely.
+
+## CI
+
+`.github/workflows/syncai.yml` runs syncai against the repo's own `syncai.json` on every push (except `main` and `release/*`). It builds from source (`make build`) — do **not** reintroduce the cross-repo binary download; it was removed because unauth'd `curl` to `api.github.com` from the runner hit IP rate limits and broke the workflow.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to a Coding Agent when working with code in this repository.
 
 ## Build & run
 

--- a/.github/workflows/syncai.yml
+++ b/.github/workflows/syncai.yml
@@ -19,66 +19,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-
-      - name: Get latest release tag
-        id: get_latest
-        uses: actions/github-script@v6
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
-          script: |
-            const latest = await github.rest.repos.getLatestRelease({
-              owner: 'flowmitry',
-              repo: 'syncai'
-            });
-            return latest.data.tag_name;
+          go-version-file: go.mod
 
-      - name: Cache syncai binary
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/syncai-cache
-          key: syncai-binary-${{ runner.os }}-${{ steps.get_latest.outputs.result }}
-          restore-keys: |
-            syncai-binary-${{ runner.os }}-
-
-      - name: Download syncai binary
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ${{ runner.temp }}/syncai-cache
-          # Determine OS
-          UNAME=$(uname -s)
-          case "$UNAME" in
-            Linux) OS=linux;;
-            Darwin) OS=darwin;;
-            *) echo "Unsupported OS: $UNAME"; exit 1;;
-          esac
-          # Determine ARCH
-          ARCH_RAW=$(uname -m)
-          case "$ARCH_RAW" in
-            x86_64) ARCH=amd64;;
-            aarch64|arm64) ARCH=arm64;;
-            *) echo "Unsupported ARCH: $ARCH_RAW"; exit 1;;
-          esac
-          NAME="syncai_${OS}_${ARCH}"
-          echo "Looking for asset: $NAME"
-          # Fetch download URL matching exact asset name
-          ASSET_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/flowmitry/syncai/releases/latest | jq -r ".assets[] | select(.name==\"$NAME\") | .browser_download_url")
-          if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then
-            echo "Error: Could not find asset $NAME in latest release"
-            exit 1
-          fi
-          echo "Downloading from: $ASSET_URL"
-          curl -sL "$ASSET_URL" -o ${{ runner.temp }}/syncai-cache/syncai
-          chmod +x ${{ runner.temp }}/syncai-cache/syncai
+      - name: Build syncai
+        run: make build
 
       - name: Run syncai
         run: |
-          BINARY_PATH="${{ runner.temp }}/syncai-cache/syncai"
+          BINARY_PATH="${{ github.workspace }}/bin/syncai"
           CONFIG_PATH="${{ github.workspace }}/syncai.json"
           if [ ! -f "$CONFIG_PATH" ]; then
             echo "Error: Configuration file $CONFIG_PATH not found."

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ bin
 .idea
 .DS_Store
 .aiignore
-CLAUDE.md
 syncai.exe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & run
+
+- `make build` — `go mod tidy` then build to `bin/syncai`.
+- `make run` — builds and then runs `go run ./cmd -config syncai.json`.
+- `make clean` — removes `bin/`.
+
+There is no test suite in this repo (no `*_test.go` files). Verify changes with `make build` plus a manual smoke test against a temp working directory:
+
+```bash
+./bin/syncai -workdir /tmp/syncai-smoke -config /tmp/syncai-smoke/syncai.json -no-watch
+```
+
+CLI flags: `-config`, `-workdir`, `-no-watch` (one-shot for CI), `-self-update`, `-version`, `-help`.
+
+## Architecture
+
+SyncAI is a polling watcher that propagates AI-assistant config files between agents (Cursor, Copilot, Claude Code, Codex). The whole program is a single Go binary; the moving parts split cleanly along four "sync kinds" defined in `internal/model/model.go`:
+
+| Kind     | Source config field      | Source unit            | Destination logic |
+|----------|--------------------------|------------------------|-------------------|
+| context  | `Agent.Context.Path`     | single file            | verbatim copy |
+| ignore   | `Agent.Ignore.Path`      | single file            | verbatim copy |
+| rules    | `Agent.Rules.Pattern`    | files matched by glob  | content rewritten by per-agent rules generator (frontmatter shape differs between cursor's `globs/alwaysApply` and copilot's `applyTo`) |
+| skills   | `Agent.Skills.Pattern`   | **whole directory** matched by glob | every file inside the matched dir copied verbatim, preserving the in-skill relative path |
+
+### Lifecycle
+
+1. `cmd/main.go` loads config, runs `initialSync` (dedup key `kind|stem|rel`, picks the newest mtime per logical file across agents), then enters a ticker loop at `cfg.Interval()` (default 5s).
+2. Each tick rebuilds the watched-file list via `(config.Agent).Files()` and diffs sha256 hashes against the in-memory `filesState`. Changes → `(*SyncAI).Sync`. Missing entries → `(*SyncAI).Delete`.
+3. `Files()` uses two distinct collectors: `globPattern` (file glob, used for rules) and `walkSkillDirs` (recursive walk of every matched directory, used for skills). Don't conflate them.
+
+### `Identify` is the routing decision
+
+`(*SyncAI).Identify(path)` returns `(*config.Agent, model.Kind, stem, rel)`:
+- `stem` is the wildcard capture (skill folder name, or rule file's wildcard portion).
+- `rel` is non-empty only for skills — it's the file's path relative to its skill folder.
+- `Identify` walks the agents in config order; the first match wins. Rules are checked before skills, so don't configure overlapping patterns.
+
+### Pattern matching helpers in `internal/syncai/util.go`
+
+- `matchPattern(pattern, path)` — for file patterns (rules). `*` may appear in any path component. Falls back to basename-without-extension as stem when the pattern has no `*`.
+- `matchSkillsPattern(pattern, path)` — for directory patterns (skills). The pattern is a prefix of the path; the remainder is the rel.
+- `generatePatternPath(pattern, stem)` — substitutes `stem` into every `*` component. For skills, callers join `rel` afterwards in `generatePath`.
+- `skillsBaseDir(pattern)` — the literal prefix of the pattern before its first wildcard component. Used to bound the empty-dir cleanup walk.
+
+### Two sync paths in `(*SyncAI).Sync`
+
+- **Skills** → `syncSkill`: read source bytes once, `util.WriteFile` them to every peer's substituted destination. No frontmatter parsing — skill folders may contain scripts/data that aren't markdown.
+- **Everything else** → document-stack path: parse all peers' versions of the logical file, sort with the changed path forced last (so it wins regardless of mtime), pass through `generate()` which dispatches to a per-agent `RulesGenerator` only when `kind == KindRules`. Context/ignore fall through verbatim.
+
+### Deletes and empty-dir pruning
+
+`(*SyncAI).Delete` only propagates deletions for `KindRules` and `KindSkills` (context/ignore deletions are intentionally non-propagating to avoid accidents). After each successful peer-side skill file removal, `util.PruneEmptyDirs(dirOf(dst), skillsBaseDir(dstAgent.Skills.Pattern))` walks upward removing empty dirs, stopping at the configured base — so `.codex/skills/` survives even when its last skill is deleted.
+
+### Atomic file writes
+
+`util.WriteFile` is the sole writer: temp file in the same dir → fsync → rename → fsync the dir. It returns early if destination bytes already match, which is what prevents ping-pong syncs.
+
+## Frontmatter parsing
+
+`util.ParseFile` extracts YAML frontmatter from markdown. Used by the document-stack path to merge metadata across agents in `generator.ExtractRulesMetadata`. Non-string YAML values are coerced via `cleanYAMLValue`; sequences are joined with commas. Skills bypass this entirely.
+
+## CI
+
+`.github/workflows/syncai.yml` runs syncai against the repo's own `syncai.json` on every push (except `main` and `release/*`). It builds from source (`make build`) — do **not** reintroduce the cross-repo binary download; it was removed because unauth'd `curl` to `api.github.com` from the runner hit IP rate limits and broke the workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to a Coding Agent when working with code in this repository.
 
 ## Build & run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & run
+
+- `make build` — `go mod tidy` then build to `bin/syncai`.
+- `make run` — builds and then runs `go run ./cmd -config syncai.json`.
+- `make clean` — removes `bin/`.
+
+There is no test suite in this repo (no `*_test.go` files). Verify changes with `make build` plus a manual smoke test against a temp working directory:
+
+```bash
+./bin/syncai -workdir /tmp/syncai-smoke -config /tmp/syncai-smoke/syncai.json -no-watch
+```
+
+CLI flags: `-config`, `-workdir`, `-no-watch` (one-shot for CI), `-self-update`, `-version`, `-help`.
+
+## Architecture
+
+SyncAI is a polling watcher that propagates AI-assistant config files between agents (Cursor, Copilot, Claude Code, Codex). The whole program is a single Go binary; the moving parts split cleanly along four "sync kinds" defined in `internal/model/model.go`:
+
+| Kind     | Source config field      | Source unit            | Destination logic |
+|----------|--------------------------|------------------------|-------------------|
+| context  | `Agent.Context.Path`     | single file            | verbatim copy |
+| ignore   | `Agent.Ignore.Path`      | single file            | verbatim copy |
+| rules    | `Agent.Rules.Pattern`    | files matched by glob  | content rewritten by per-agent rules generator (frontmatter shape differs between cursor's `globs/alwaysApply` and copilot's `applyTo`) |
+| skills   | `Agent.Skills.Pattern`   | **whole directory** matched by glob | every file inside the matched dir copied verbatim, preserving the in-skill relative path |
+
+### Lifecycle
+
+1. `cmd/main.go` loads config, runs `initialSync` (dedup key `kind|stem|rel`, picks the newest mtime per logical file across agents), then enters a ticker loop at `cfg.Interval()` (default 5s).
+2. Each tick rebuilds the watched-file list via `(config.Agent).Files()` and diffs sha256 hashes against the in-memory `filesState`. Changes → `(*SyncAI).Sync`. Missing entries → `(*SyncAI).Delete`.
+3. `Files()` uses two distinct collectors: `globPattern` (file glob, used for rules) and `walkSkillDirs` (recursive walk of every matched directory, used for skills). Don't conflate them.
+
+### `Identify` is the routing decision
+
+`(*SyncAI).Identify(path)` returns `(*config.Agent, model.Kind, stem, rel)`:
+- `stem` is the wildcard capture (skill folder name, or rule file's wildcard portion).
+- `rel` is non-empty only for skills — it's the file's path relative to its skill folder.
+- `Identify` walks the agents in config order; the first match wins. Rules are checked before skills, so don't configure overlapping patterns.
+
+### Pattern matching helpers in `internal/syncai/util.go`
+
+- `matchPattern(pattern, path)` — for file patterns (rules). `*` may appear in any path component. Falls back to basename-without-extension as stem when the pattern has no `*`.
+- `matchSkillsPattern(pattern, path)` — for directory patterns (skills). The pattern is a prefix of the path; the remainder is the rel.
+- `generatePatternPath(pattern, stem)` — substitutes `stem` into every `*` component. For skills, callers join `rel` afterwards in `generatePath`.
+- `skillsBaseDir(pattern)` — the literal prefix of the pattern before its first wildcard component. Used to bound the empty-dir cleanup walk.
+
+### Two sync paths in `(*SyncAI).Sync`
+
+- **Skills** → `syncSkill`: read source bytes once, `util.WriteFile` them to every peer's substituted destination. No frontmatter parsing — skill folders may contain scripts/data that aren't markdown.
+- **Everything else** → document-stack path: parse all peers' versions of the logical file, sort with the changed path forced last (so it wins regardless of mtime), pass through `generate()` which dispatches to a per-agent `RulesGenerator` only when `kind == KindRules`. Context/ignore fall through verbatim.
+
+### Deletes and empty-dir pruning
+
+`(*SyncAI).Delete` only propagates deletions for `KindRules` and `KindSkills` (context/ignore deletions are intentionally non-propagating to avoid accidents). After each successful peer-side skill file removal, `util.PruneEmptyDirs(dirOf(dst), skillsBaseDir(dstAgent.Skills.Pattern))` walks upward removing empty dirs, stopping at the configured base — so `.codex/skills/` survives even when its last skill is deleted.
+
+### Atomic file writes
+
+`util.WriteFile` is the sole writer: temp file in the same dir → fsync → rename → fsync the dir. It returns early if destination bytes already match, which is what prevents ping-pong syncs.
+
+## Frontmatter parsing
+
+`util.ParseFile` extracts YAML frontmatter from markdown. Used by the document-stack path to merge metadata across agents in `generator.ExtractRulesMetadata`. Non-string YAML values are coerced via `cleanYAMLValue`; sequences are joined with commas. Skills bypass this entirely.
+
+## CI
+
+`.github/workflows/syncai.yml` runs syncai against the repo's own `syncai.json` on every push (except `main` and `release/*`). It builds from source (`make build`) — do **not** reintroduce the cross-repo binary download; it was removed because unauth'd `curl` to `api.github.com` from the runner hit IP rate limits and broke the workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to a Coding Agent when working with code in this repository.
 
 ## Build & run
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ agents:
 
 * Cursor
 * GitHub Copilot
-* JetBrains Junie
 * Cline
 * Claude Code
 * OpenAI Codex

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the other agents.
 
 ## Supported sync types
 
-SyncAI supports three kinds of synced items in agent configurations:
+SyncAI supports four kinds of synced items in agent configurations:
 
 - **context** — a single file with general AI guidelines or assistant context (for example `AGENTS.md` or `CLAUDE.md`). Configure with `context.path`. The file is copied verbatim to the target location.
 
@@ -30,7 +30,9 @@ SyncAI supports three kinds of synced items in agent configurations:
 
 - **ignore** — a single file with instructions telling the assistant what to ignore (for example `.copilotignore`). Configure with `ignore.path`. The file is copied verbatim.
 
-These sections can be used together for each agent to keep context, many rule files, and ignore files in sync across different assistants.
+- **skills** — a directory pattern matching skill folders (for example `.claude/skills/*`). Each match is treated as a whole skill: every file inside the directory (including nested subfolders, scripts, data, etc.) is mirrored to the equivalent location at every other agent that has a `skills` pattern. The `*` wildcard captures the skill's folder name and is substituted into the target pattern. Skill files are copied verbatim. Deletions are propagated and now-empty target directories are cleaned up automatically down to the configured base directory, which is preserved.
+
+These sections can be used together for each agent to keep context, rule files, ignore files, and skill folders in sync across different assistants.
 
 ## Quick start
 
@@ -75,6 +77,13 @@ The default configuration is a simple JSON map (for more details check [syncai.j
       // optional "ignore" section
       "ignore": {
         "path": "/path/to/your/ignorefile"
+      },
+      // optional "skills" section: directory pattern matching skill folders.
+      // The `*` is captured as the skill folder name and substituted on the
+      // other agents. Every file inside the matched directory (recursively)
+      // is mirrored.
+      "skills": {
+        "pattern": ".<AGENT>/skills/*"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ agents:
 
 * Cursor
 * GitHub Copilot
-* Cline
 * Claude Code
 * OpenAI Codex
 
@@ -65,7 +64,7 @@ The default configuration is a simple JSON map (for more details check [syncai.j
       // agent name
       "name": "<AGENT_NAME>",
       // optional "rules" section
-      // GitHub Copilot calls it "instructions", Cursor and Cline "rules"
+      // GitHub Copilot calls it "instructions", Cursor "rules"
       "rules": {
         "pattern": ".<AGENT>/rules/*.md"
       },

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -171,12 +171,12 @@ func initialSync(cfg config.Config, sync *syncai.SyncAI) {
 			}
 			modT := fi.ModTime()
 
-			_, kind, stem := sync.Identify(path)
+			_, kind, stem, rel := sync.Identify(path)
 			if kind == model.KindUnknown {
 				continue
 			}
 
-			key := string(kind) + "|" + stem
+			key := string(kind) + "|" + stem + "|" + rel
 			if cur, ok := latest[key]; !ok || modT.After(cur.mod) {
 				latest[key] = newest{path: path, mod: modT}
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -27,11 +28,16 @@ type Ignore struct {
 	Path string `json:"path"`
 }
 
+type Skills struct {
+	Pattern string `json:"pattern"`
+}
+
 type Agent struct {
 	Name    string  `json:"name"`
 	Rules   Rules   `json:"rules"`
 	Context Context `json:"context"`
 	Ignore  Ignore  `json:"ignore"`
+	Skills  Skills  `json:"skills"`
 }
 
 type Meta struct {
@@ -117,26 +123,89 @@ func (a Agent) Files() []string {
 
 	// Include rules only if a non-empty pattern is configured
 	if pat := strings.TrimSpace(a.Rules.Pattern); pat != "" {
-		matches, err := filepath.Glob(pat)
-		if err != nil {
-			log.Printf("glob %s: %v", pat, err)
-		}
-		for _, match := range matches {
-			path := strings.TrimSpace(match)
-			if path != "" {
-				_, err := os.Stat(path)
-				if err != nil {
-					if os.IsNotExist(err) {
-						// File may not exist yet; silently ignore
-						continue
-					}
-					log.Printf("file error %s: %v", path, err)
-					continue
-				}
-				files = append(files, path)
-			}
-		}
+		files = append(files, globPattern(pat)...)
+	}
+
+	// Include skills only if a non-empty pattern is configured.
+	// Skills patterns match directories; every regular file inside each
+	// matched directory is watched so the entire skill folder syncs.
+	if pat := strings.TrimSpace(a.Skills.Pattern); pat != "" {
+		files = append(files, walkSkillDirs(pat)...)
 	}
 
 	return files
+}
+
+func globPattern(pat string) []string {
+	matches, err := filepath.Glob(pat)
+	if err != nil {
+		log.Printf("glob %s: %v", pat, err)
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		path := strings.TrimSpace(match)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			log.Printf("file error %s: %v", path, err)
+			continue
+		}
+		// Skip directories — only file matches are watched
+		if info.IsDir() {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+func walkSkillDirs(pat string) []string {
+	matches, err := filepath.Glob(pat)
+	if err != nil {
+		log.Printf("glob %s: %v", pat, err)
+		return nil
+	}
+	var out []string
+	for _, match := range matches {
+		path := strings.TrimSpace(match)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Printf("file error %s: %v", path, err)
+			}
+			continue
+		}
+		if !info.IsDir() {
+			// Pattern matched a file directly; treat it as a single-file skill.
+			out = append(out, path)
+			continue
+		}
+		err = filepath.WalkDir(path, func(p string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				log.Printf("walk error %s: %v", p, walkErr)
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			out = append(out, p)
+			return nil
+		})
+		if err != nil {
+			log.Printf("walk %s: %v", path, err)
+		}
+	}
+	return out
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -11,6 +11,7 @@ const (
 	KindRules   Kind = "rules"
 	KindContext Kind = "context"
 	KindIgnore  Kind = "ignore"
+	KindSkills  Kind = "skills"
 )
 
 const (

--- a/internal/syncai/syncai.go
+++ b/internal/syncai/syncai.go
@@ -25,14 +25,15 @@ func New(cfg config.Config) *SyncAI {
 // Delete propagates deletion of a watched file to corresponding destinations across other agents.
 func (s *SyncAI) Delete(path string) ([]string, error) {
 	result := make([]string, 0)
-	srcAgent, kind, stem := s.Identify(path)
+	srcAgent, kind, stem, rel := s.Identify(path)
 	result = append(result, path)
 	if kind == model.KindUnknown || srcAgent == nil {
 		return result, nil // nothing to do
 	}
 
-	// Only propagate deletions for rules. Context/ignore deletions are not propagated to avoid accidental removals.
-	if kind != model.KindRules {
+	// Only propagate deletions for rules and skills. Context/ignore deletions
+	// are not propagated to avoid accidental removals.
+	if kind != model.KindRules && kind != model.KindSkills {
 		return result, nil
 	}
 
@@ -42,19 +43,24 @@ func (s *SyncAI) Delete(path string) ([]string, error) {
 			continue
 		}
 
-		dstPath := s.generatePath(dstAgent, kind, stem)
+		dstPath := s.generatePath(dstAgent, kind, stem, rel)
 		if dstPath == "" {
 			continue
 		}
 		if err := os.Remove(dstPath); err != nil {
 			if os.IsNotExist(err) {
-				// Already gone at the destination; nothing to do
+				// Already gone at the destination
 				result = append(result, dstPath)
-				continue
+			} else {
+				return result, err
 			}
-			return result, err
 		} else {
 			result = append(result, dstPath)
+		}
+
+		// For skills, prune now-empty parent dirs up to the skills base.
+		if kind == model.KindSkills {
+			util.PruneEmptyDirs(filepath.Dir(dstPath), skillsBaseDir(dstAgent.Skills.Pattern))
 		}
 	}
 	return result, nil
@@ -63,9 +69,13 @@ func (s *SyncAI) Delete(path string) ([]string, error) {
 // Sync propagates creation/update of a watched file across other agents.
 func (s *SyncAI) Sync(path string) ([]string, error) {
 	result := make([]string, 0)
-	srcAgent, kind, stem := s.Identify(path)
+	srcAgent, kind, stem, rel := s.Identify(path)
 	if kind == model.KindUnknown || srcAgent == nil {
 		return result, nil // unknown file, ignore
+	}
+
+	if kind == model.KindSkills {
+		return s.syncSkill(srcAgent, path, stem, rel)
 	}
 
 	stack := model.DocumentStack{
@@ -83,7 +93,7 @@ func (s *SyncAI) Sync(path string) ([]string, error) {
 		if dstAgent.Name == srcAgent.Name {
 			docPath = path
 		} else {
-			docPath = s.generatePath(dstAgent, kind, stem)
+			docPath = s.generatePath(dstAgent, kind, stem, rel)
 			if docPath == "" {
 				continue
 			}
@@ -103,7 +113,7 @@ func (s *SyncAI) Sync(path string) ([]string, error) {
 			continue
 		}
 
-		dstPath := s.generatePath(dstAgent, kind, stem)
+		dstPath := s.generatePath(dstAgent, kind, stem, rel)
 		if strings.TrimSpace(dstPath) == "" {
 			// No target path configured for this agent/kind; skip writing
 			continue
@@ -122,50 +132,58 @@ func (s *SyncAI) Sync(path string) ([]string, error) {
 	return result, nil
 }
 
-func (s *SyncAI) Identify(path string) (*config.Agent, model.Kind, string) {
+// syncSkill copies a single file inside a skill folder verbatim to every
+// other agent that has a skills pattern configured.
+func (s *SyncAI) syncSkill(srcAgent *config.Agent, path, stem, rel string) ([]string, error) {
+	result := make([]string, 0)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return result, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	for i := range s.cfg.Agents {
+		dstAgent := &s.cfg.Agents[i]
+		if srcAgent.Name == dstAgent.Name {
+			continue
+		}
+		if strings.TrimSpace(dstAgent.Skills.Pattern) == "" {
+			continue
+		}
+		dstPath := s.generatePath(dstAgent, model.KindSkills, stem, rel)
+		if strings.TrimSpace(dstPath) == "" {
+			continue
+		}
+		if err := util.WriteFile(dstPath, data); err != nil {
+			return result, fmt.Errorf("write %s for agent %s: %w", dstPath, dstAgent.Name, err)
+		}
+		result = append(result, dstPath)
+		log.Printf("Skill file %s synced to %s", path, dstPath)
+	}
+	return result, nil
+}
+
+func (s *SyncAI) Identify(path string) (*config.Agent, model.Kind, string, string) {
 	clean := filepath.Clean(path)
 	for i := range s.cfg.Agents {
 		a := &s.cfg.Agents[i]
-		if filepath.Clean(a.Context.Path) == clean {
-			return a, model.KindContext, ""
+		if p := strings.TrimSpace(a.Context.Path); p != "" && filepath.Clean(p) == clean {
+			return a, model.KindContext, "", ""
 		}
-		if filepath.Clean(a.Ignore.Path) == clean {
-			return a, model.KindIgnore, ""
+		if p := strings.TrimSpace(a.Ignore.Path); p != "" && filepath.Clean(p) == clean {
+			return a, model.KindIgnore, "", ""
 		}
-		if strings.TrimSpace(a.Rules.Pattern) != "" {
-			// Match by comparing the directory and base pattern, independent of file existence
-			pattern := a.Rules.Pattern
-			patDir := filepath.Clean(filepath.Dir(pattern))
-			fileDir := filepath.Clean(filepath.Dir(clean))
-			if patDir == fileDir {
-				basePattern := filepath.Base(pattern)
-				filename := filepath.Base(clean)
-				// Attempt to extract stem depending on wildcard presence
-				if strings.Contains(basePattern, "*") {
-					parts := strings.Split(basePattern, "*")
-					prefix := parts[0]
-					suffix := ""
-					if len(parts) > 1 {
-						suffix = parts[len(parts)-1]
-					}
-					if strings.HasPrefix(filename, prefix) && strings.HasSuffix(filename, suffix) {
-						stem := strings.TrimPrefix(filename, prefix)
-						stem = strings.TrimSuffix(stem, suffix)
-						return a, model.KindRules, stem
-					}
-				} else {
-					if filename == basePattern {
-						stem := filename
-						if ext := filepath.Ext(stem); ext != "" {
-							stem = strings.TrimSuffix(stem, ext)
-						}
-						return a, model.KindRules, stem
-					}
-				}
+		if pat := strings.TrimSpace(a.Rules.Pattern); pat != "" {
+			if ok, stem := matchPattern(pat, clean); ok {
+				return a, model.KindRules, stem, ""
+			}
+		}
+		if pat := strings.TrimSpace(a.Skills.Pattern); pat != "" {
+			if ok, stem, rel := matchSkillsPattern(pat, clean); ok {
+				return a, model.KindSkills, stem, rel
 			}
 		}
 	}
-	return nil, model.KindUnknown, ""
+	return nil, model.KindUnknown, "", ""
 }
 
 func generate(s *model.DocumentStack, agent string) ([]byte, error) {

--- a/internal/syncai/util.go
+++ b/internal/syncai/util.go
@@ -7,7 +7,7 @@ import (
 	"syncai/internal/model"
 )
 
-func (s *SyncAI) generatePath(agent *config.Agent, kind model.Kind, stem string) string {
+func (s *SyncAI) generatePath(agent *config.Agent, kind model.Kind, stem, rel string) string {
 	if agent == nil {
 		return ""
 	}
@@ -17,26 +17,153 @@ func (s *SyncAI) generatePath(agent *config.Agent, kind model.Kind, stem string)
 	case model.KindIgnore:
 		return agent.Ignore.Path
 	case model.KindRules:
-		pattern := strings.TrimSpace(agent.Rules.Pattern)
-		if pattern == "" {
+		return generatePatternPath(agent.Rules.Pattern, stem)
+	case model.KindSkills:
+		dir := generatePatternPath(agent.Skills.Pattern, stem)
+		if dir == "" {
 			return ""
 		}
-		dir := filepath.Dir(pattern)
-		base := filepath.Base(pattern)
-		var filename string
-		if strings.Contains(base, "*") {
-			filename = strings.ReplaceAll(base, "*", stem)
-		} else {
-			// No wildcard in base, just use stem with the same extension as the pattern base
-			ext := filepath.Ext(base)
-			if ext == "" {
-				filename = stem
-			} else {
-				filename = stem + ext
-			}
+		if rel == "" {
+			return dir
 		}
-		return filepath.Join(dir, filename)
+		return filepath.Join(dir, rel)
 	default:
 		return ""
 	}
+}
+
+// generatePatternPath substitutes the stem into every "*" component in the
+// pattern. A pattern with no "*" is returned unchanged.
+func generatePatternPath(pattern, stem string) string {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return ""
+	}
+	if !strings.Contains(pattern, "*") {
+		return pattern
+	}
+	parts := strings.Split(filepath.ToSlash(pattern), "/")
+	for i, c := range parts {
+		if strings.Contains(c, "*") {
+			parts[i] = strings.ReplaceAll(c, "*", stem)
+		}
+	}
+	return filepath.FromSlash(strings.Join(parts, "/"))
+}
+
+// matchPattern matches a file path against a glob-like pattern that may
+// contain "*" in any component. Returns the captured stem on success. For
+// patterns with no "*", the basename of path without its extension is
+// returned as the stem (legacy rules behavior).
+func matchPattern(pattern, path string) (bool, string) {
+	if strings.TrimSpace(pattern) == "" {
+		return false, ""
+	}
+	pNorm := filepath.ToSlash(filepath.Clean(pattern))
+	fNorm := filepath.ToSlash(filepath.Clean(path))
+	pParts := strings.Split(pNorm, "/")
+	fParts := strings.Split(fNorm, "/")
+	if len(pParts) != len(fParts) {
+		return false, ""
+	}
+	hasWildcard := strings.Contains(pNorm, "*")
+	var stem string
+	var stemSet bool
+	for i := range pParts {
+		pc, fc := pParts[i], fParts[i]
+		if strings.Contains(pc, "*") {
+			parts := strings.SplitN(pc, "*", 2)
+			prefix, suffix := parts[0], ""
+			if len(parts) > 1 {
+				suffix = parts[1]
+			}
+			if len(fc) < len(prefix)+len(suffix) ||
+				!strings.HasPrefix(fc, prefix) ||
+				!strings.HasSuffix(fc, suffix) {
+				return false, ""
+			}
+			captured := fc[len(prefix) : len(fc)-len(suffix)]
+			if stemSet && captured != stem {
+				return false, ""
+			}
+			stem = captured
+			stemSet = true
+		} else if pc != fc {
+			return false, ""
+		}
+	}
+	if !hasWildcard {
+		base := filepath.Base(path)
+		if ext := filepath.Ext(base); ext != "" {
+			base = strings.TrimSuffix(base, ext)
+		}
+		stem = base
+	}
+	return true, stem
+}
+
+// matchSkillsPattern checks whether a file path lies inside a skill directory
+// matched by pattern. The pattern is treated as a directory glob; the file
+// path may have additional components after the matched directory. Returns
+// (matched, stem, rel) where stem is the captured wildcard text (skill folder
+// name) and rel is the file's path relative to the skill directory.
+func matchSkillsPattern(pattern, path string) (bool, string, string) {
+	if strings.TrimSpace(pattern) == "" {
+		return false, "", ""
+	}
+	pNorm := filepath.ToSlash(filepath.Clean(pattern))
+	fNorm := filepath.ToSlash(filepath.Clean(path))
+	pParts := strings.Split(pNorm, "/")
+	fParts := strings.Split(fNorm, "/")
+	if len(fParts) < len(pParts) {
+		return false, "", ""
+	}
+	var stem string
+	var stemSet bool
+	for i := range pParts {
+		pc, fc := pParts[i], fParts[i]
+		if strings.Contains(pc, "*") {
+			parts := strings.SplitN(pc, "*", 2)
+			prefix, suffix := parts[0], ""
+			if len(parts) > 1 {
+				suffix = parts[1]
+			}
+			if len(fc) < len(prefix)+len(suffix) ||
+				!strings.HasPrefix(fc, prefix) ||
+				!strings.HasSuffix(fc, suffix) {
+				return false, "", ""
+			}
+			captured := fc[len(prefix) : len(fc)-len(suffix)]
+			if stemSet && captured != stem {
+				return false, "", ""
+			}
+			stem = captured
+			stemSet = true
+		} else if pc != fc {
+			return false, "", ""
+		}
+	}
+	rel := strings.Join(fParts[len(pParts):], "/")
+	return true, stem, rel
+}
+
+// skillsBaseDir returns the prefix of pattern up to (but not including) its
+// first wildcard component. For ".codex/skills/*" it returns ".codex/skills".
+// For patterns with no wildcard it returns the pattern's parent dir.
+func skillsBaseDir(pattern string) string {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return ""
+	}
+	pNorm := filepath.ToSlash(filepath.Clean(pattern))
+	parts := strings.Split(pNorm, "/")
+	for i, c := range parts {
+		if strings.Contains(c, "*") {
+			if i == 0 {
+				return ""
+			}
+			return filepath.FromSlash(strings.Join(parts[:i], "/"))
+		}
+	}
+	return filepath.Dir(filepath.FromSlash(pNorm))
 }

--- a/internal/util/files.go
+++ b/internal/util/files.go
@@ -94,6 +94,35 @@ func FileHash(path string) (string, error) {
 	return hex.EncodeToString(sum), nil
 }
 
+// PruneEmptyDirs removes startDir and each ancestor up to (but not including)
+// stopDir as long as the directory is empty. It is a no-op if startDir does
+// not exist, is not empty, or escapes stopDir. Errors other than not-exist
+// are ignored — best-effort cleanup.
+func PruneEmptyDirs(startDir, stopDir string) {
+	if startDir == "" {
+		return
+	}
+	cur := filepath.Clean(startDir)
+	stop := filepath.Clean(stopDir)
+	for cur != "" && cur != "." && cur != "/" && cur != stop {
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			return
+		}
+		if len(entries) > 0 {
+			return
+		}
+		if err := os.Remove(cur); err != nil {
+			return
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return
+		}
+		cur = parent
+	}
+}
+
 func IsFileExists(path string) bool {
 	if path == "" {
 		return false

--- a/syncai.json
+++ b/syncai.json
@@ -32,12 +32,6 @@
       }
     },
     {
-      "name": "cline",
-      "rules": {
-        "pattern": ".clinerules/*.md"
-      }
-    },
-    {
       "name": "claude",
       "context": {
         "path": "CLAUDE.md"

--- a/syncai.json
+++ b/syncai.json
@@ -47,15 +47,6 @@
       }
     },
     {
-      "name": "junie",
-      "context": {
-        "path": ".junie/guidelines.md"
-      },
-      "ignore": {
-        "path": ".aiignore"
-      }
-    },
-    {
       "name": "codex",
       "context": {
         "path": "AGENTS.md"

--- a/syncai.json
+++ b/syncai.json
@@ -35,6 +35,9 @@
       "name": "claude",
       "context": {
         "path": "CLAUDE.md"
+      },
+      "skills": {
+        "pattern": ".claude/skills/*"
       }
     },
     {
@@ -50,6 +53,9 @@
       "name": "codex",
       "context": {
         "path": "AGENTS.md"
+      },
+      "skills": {
+        "pattern": ".codex/skills/*"
       }
     }
   ]

--- a/syncai.json
+++ b/syncai.json
@@ -23,6 +23,9 @@
       },
       "context": {
         "path": ".github/copilot-instructions.md"
+      },
+      "skills": {
+        "pattern": ".github/skills/*"
       }
     },
     {

--- a/syncai.json
+++ b/syncai.json
@@ -14,6 +14,9 @@
       },
       "ignore": {
         "path": ".cursorignore"
+      },
+      "skills": {
+        "pattern": ".cursor/skills/*"
       }
     },
     {


### PR DESCRIPTION
## Summary
This PR adds support for a new `skills` sync type that allows syncing entire skill directories across agents. Skills patterns match directories and mirror all files within them (including nested subdirectories) to equivalent locations in other agents' skill directories.

## Key Changes

- **New `skills` configuration type**: Added `Skills` struct to agent config with a `pattern` field for matching skill directories
- **Pattern matching functions**: Implemented three new utility functions:
  - `generatePatternPath()`: Substitutes stem into wildcard components in patterns
  - `matchPattern()`: Matches file paths against glob-like patterns with `*` wildcards
  - `matchSkillsPattern()`: Matches files inside skill directories, capturing both the skill name (stem) and relative path within the skill
  - `skillsBaseDir()`: Extracts the base directory path up to the first wildcard component

- **Updated `Identify()` method**: Now returns four values including `rel` (relative path within skill directory) and detects both rules and skills patterns
- **New `syncSkill()` method**: Handles verbatim copying of skill files across agents, preserving directory structure
- **Enhanced `Delete()` method**: Now propagates skill deletions and prunes empty parent directories up to the skills base directory
- **Updated `generatePath()` method**: Accepts additional `rel` parameter to support nested skill file paths

- **File watching improvements**: 
  - `Files()` method now walks skill directories to watch all contained files
  - Added `globPattern()` and `walkSkillDirs()` helper functions for pattern matching
  - Skills patterns match directories; all regular files inside are watched

- **Utility enhancement**: Added `PruneEmptyDirs()` function to clean up empty directories after skill deletions

- **Documentation**: Updated README to describe the new skills sync type with examples

## Implementation Details

- Skills use the same `*` wildcard syntax as rules, but the wildcard captures the skill folder name rather than a file stem
- Skill files are copied verbatim (unlike rules which may have stem substitution)
- Deletions within skill directories are propagated and now-empty parent directories are automatically cleaned up
- The relative path within a skill directory is preserved when syncing to other agents

https://claude.ai/code/session_01YbZfkQuNSsHiqxEzyNWg7r