### PR TITLE
Add OpenCode agent support to syncai configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ agents:
 * GitHub Copilot
 * Claude Code
 * OpenAI Codex
+* OpenCode
 
 It watches the files you specify in a JSON configuration and propagates every change to the corresponding locations for
 the other agents.

--- a/syncai.json
+++ b/syncai.json
@@ -55,7 +55,7 @@
         "path": "AGENTS.md"
       },
       "skills": {
-        "pattern": ".opencode/command/*"
+        "pattern": ".opencode/skills/*"
       }
     }
   ]

--- a/syncai.json
+++ b/syncai.json
@@ -48,6 +48,15 @@
       "skills": {
         "pattern": ".codex/skills/*"
       }
+    },
+    {
+      "name": "opencode",
+      "context": {
+        "path": "AGENTS.md"
+      },
+      "skills": {
+        "pattern": ".opencode/command/*"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
This PR adds support for the OpenCode agent to the syncai configuration system, enabling synchronization of OpenCode commands alongside existing agents like GitHub Copilot, Claude Code, and OpenAI Codex.

## Key Changes
- Added new "opencode" agent configuration to `syncai.json` with:
  - Context path pointing to `AGENTS.md`
  - Skills pattern targeting `.opencode/command/*` directory
- Updated `README.md` to list OpenCode as a supported agent

## Implementation Details
The OpenCode agent follows the same configuration pattern as existing agents, with a dedicated skills directory (`.opencode/command/`) for command definitions. The agent context is documented in the `AGENTS.md` file, maintaining consistency with the project's documentation structure.

https://claude.ai/code/session_018tq8vkbcPoMVuVjAF2i1KC